### PR TITLE
reorganize modules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,13 @@ Pull requests are always welcome. You probably want to file an issue first, to a
 
 Some minimal guidelines for contributing. These may be loosely followed or totally ignored - any code is better than no code.
 
-These are just personal preferences, not hard rules; reading them might help you to reason about my code. I won't turn down a PR just for not following them.
+These are just personal preferences, not hard rules; reading them might help you to reason about my code. 
+I won't turn down a PR just for not following them.
 
 - Follow [Tiger Style](https://github.com/tigerbeetle/tigerbeetle/blob/main/docs/TIGER_STYLE.md) as closely as possible.
-- All functions should include a doc comment.
-- Code comments are fine, I'm not a comment hater. But if the comment could be replaced with an assertion, do so. Which leads me to my next guideline...
+- Any functions should include a brief doc comment listing any known footguns or gotchas.
+- Code comments are fine, I'm not a comment hater. 
+    - If the comment could be replaced with an assertion, do so.
 - There is no such thing as too many assertions. Feel free to spam them.
     - If a value will always fall within a smaller subrange of its type's possible values, assert it. (or use an enum if practical)
         - i.e. if an integer `i` will always be greater than 5, then `assert(i > 5)` as early as possible, or before operating on it.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,17 @@
+# TODO
+
+- Feature: Options for potential additional output formats? For use with other bars if they support custom modules.
+
+- Feature: Parse mount flags, include certain ones in tooltip if present
+    - Options that you might want to check for i.e. `noexec`, `users`/`user_id=`/`group_id=`, `_netdev`, et al
+    - Don't show in `.compact` mode
+
+- Feature: Configurable update signal number
+    - Allow to format as either `RTMIN + n` or explicit `n`
+    - Assert between 32-64
+
+- Organization: Move everything that's *specific to this module* to `main.zig`; let `root.zig` contain only helper/shareable functions that can be used by other future modules.
+
+- Issue: `statvfs()` may hang on network filesystems. Skip filesystem if `_netdev` mount flag found?
+
+- Refactor: Use one of the existing arg parsing libs, so I can add more planned options.

--- a/build.zig
+++ b/build.zig
@@ -6,10 +6,9 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     const mod = b.addModule(
-        "disk-usage-monitor-waybar",
+        "wbmod-utils",
         .{
             .root_source_file = b.path("src/root.zig"),
-
             .target = target,
         },
     );
@@ -18,12 +17,10 @@ pub fn build(b: *std.Build) void {
         .name = "disk-usage-monitor-waybar",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
-
             .target = target,
             .optimize = optimize,
-
             .imports = &.{
-                .{ .name = "disk-usage-monitor-waybar", .module = mod },
+                .{ .name = "wbmod-utils", .module = mod },
             },
         }),
     });

--- a/src/root.zig
+++ b/src/root.zig
@@ -2,27 +2,18 @@
 //! Zig 0.15.1 + libc
 
 const std = @import("std");
-const ArrayList = std.ArrayList;
+
 const ascii = std.ascii;
-const enums = std.enums;
 const fmt = std.fmt;
 const fs = std.fs;
 const Io = std.Io;
 const json = std.json;
 const linux = std.os.linux;
 const mem = std.mem;
-const meta = std.meta;
 const posix = std.posix;
-const process = std.process;
-
-const c_sys = @cImport({
-    @cInclude("sys/statvfs.h");
-});
 
 pub const gibi = 1_073_741_824; // 1024^3
 pub const kibi = 1024;
-
-const stat_has_ftype: bool = @hasField(c_sys.struct_statvfs, "f_type");
 
 /// Same as `std.debug.assert`
 pub fn assert(ok: bool) void {
@@ -50,10 +41,11 @@ pub fn unbufferedPrint(bytes: []const u8) error{WriteFailed}!void {
     return;
 }
 
-/// Send realtime signal (`RTMIN` + `n`) to Waybar process, to signal module update.
+/// Send realtime signal (`RTMIN` + `n`) to Waybar process, (by pid) to signal module update.
 ///
-/// Asserts `pid > 0` and `n <= 32`
+/// Asserts `pid > 0`, and `n <= 32`
 ///
+/// To get pid, see `.getPidByName()`
 /// ref: https://manpages.org/signal/7
 pub fn rtSig(pid: linux.pid_t, n: u8) !void {
     assert(pid > 0);
@@ -159,176 +151,6 @@ pub fn readFileBytes(allocator: mem.Allocator, file_path: []const u8) ![]const u
     return file_contents;
 }
 
-/// Parse mounts file contents, stat each mountpoint, return the interesting data.
-/// Caller must free `result.tooltip`.
-///
-/// `file_contents` expects the contents of `/proc/mounts`.
-///
-/// I've tried 2 different memory models for creating tooltip text:
-///
-/// - Add each line of text created to an `ArrayList([]const u8)`, then move all to a final `[]u8` slice (freeing each allocated line immediately after it's copied), and return owned slice. This involves a little more code.
-///
-/// - Append each line as *bytes* directly to an `ArrayList(u8)` (using `.appendSlice`), and return owned slice of its `.items` (skip the intermediate list).
-///
-/// The second option results in a slightly higher PEAK heap usage towards end of run, but for most of runtime, total usage is lower. Requires tracking allocations in a second list of slices to be freed, if not using arena.
-///
-/// I've chosen to stick with #2, for simplicity. But also because I don't feel like re-writing it again. ;)
-///
-/// TODO: Separate into smaller functions
-pub fn parseMnts(allocator: mem.Allocator, file_contents: []const u8, options: *Options, w: *Io.Writer.Allocating) !OutputWaybar {
-    var tooltip_bytes: ArrayList(u8) = .empty;
-    errdefer tooltip_bytes.deinit(allocator);
-
-    // 1.) Maintain references to output lines that still need freed after being copied to `tooltip_bytes`
-    var need_freed: ArrayList([]const u8) = .empty;
-    defer need_freed.deinit(allocator);
-    // 2.) and free them:
-    defer for (need_freed.items) |line| {
-        allocator.free(line[0..]);
-    };
-
-    // Percentage used of root mount (`/`).
-    var root_used_pcent: u8 = 0;
-
-    // This doesn't need to be a named block, but it's easier to read and helps infer scope.
-    parse_entries: {
-        const line_1_fmt = "{s} on {s}\r";
-        const line_2_fmt = "\tSize: {d:.2} GiB\r";
-
-        var stat: c_sys.struct_statvfs = .{};
-
-        var lines_iter = mem.tokenizeScalar(u8, file_contents, '\n');
-
-        while (lines_iter.next()) |line| {
-            // NOTE: This might break if mount point contains spaces
-            var words_iter = mem.tokenizeScalar(u8, line, ' ');
-
-            const dev_name = words_iter.next() orelse break; // fs_spec (dev name - if null, reached end)
-
-            const mount_point = words_iter.next().?; // 2nd "word"
-            const mount_point_z = try allocator.dupeZ(u8, mount_point);
-            defer allocator.free(mount_point_z);
-
-            assert(mount_point.len <= fs.max_path_bytes);
-            for (mount_point) |c| assert(std.ascii.isPrint(c));
-
-            const fs_type_fallback = words_iter.next() orelse continue; // 3rd word
-
-            // TODO: Parse flags and keep important ones to display in tooltip
-            // const flags = words_iter.next().?; // 4th word - mount flags
-
-            // Call `statvfs` on the mount point
-            const rc = c_sys.statvfs(mount_point_z.ptr, &stat);
-            if (rc != 0) continue; // 0 = Failure, skip to next entry
-
-            // Check if `f_type` is in `ignored_ftypes` enum, and if so, skip to next iteration
-            // If `struct_statvfs.f_type` field doesn't exist, fall back to fs type from `/proc/mounts`
-            var to_skip = false;
-            if (stat_has_ftype) {
-                const f_type: c_uint = stat.f_type;
-                if (ignored_ftypes.fromCInt(f_type) != null) to_skip = true;
-            } else {
-                if (ignored_ftypes.hasField(fs_type_fallback)) to_skip = true;
-            }
-            if (to_skip) continue;
-
-            // Calculate total usage of this filesystem
-            const total: c_ulong = stat.f_blocks * stat.f_frsize;
-            if (total == 0) continue; // Skip to next entry if zero size (most vfs entries).
-            const free: c_ulong = stat.f_bfree * stat.f_frsize;
-            const used: c_ulong = total - free;
-
-            const used_pcent: f32 = (@as(f32, @floatFromInt(used)) / @as(f32, @floatFromInt(total))) * 100;
-
-            assert(0 <= used_pcent and used_pcent <= 100); // Percentage calculated incorrectly
-
-            // Save root mount (`/`) used %, when we come across its entry.
-            if (mem.eql(u8, mount_point_z, "/")) {
-                root_used_pcent = @intFromFloat(used_pcent); // Rounded towards zero
-                assert(0 <= root_used_pcent and root_used_pcent <= 100); // Percentage calculated incorrectly
-            }
-
-            append_tooltip: {
-
-                // ## Assemble tooltip paragraph for this filesystem, line by line, appending each to `tooltip_bytes`
-
-                // Line 1 - dev name + mountpoint
-                try w.writer.print(line_1_fmt, .{ dev_name, mount_point_z });
-                const ln_1 = try w.toOwnedSlice();
-                errdefer allocator.free(ln_1);
-
-                try tooltip_bytes.appendSlice(allocator, ln_1);
-                try need_freed.append(allocator, ln_1);
-
-                // Line 2 - total size
-                // Only include if format=.normal -- Skip if .compact
-                if (options.*.tooltip_fmt == .normal) {
-                    try w.writer.print(line_2_fmt, .{@as(f32, @floatFromInt(total)) / gibi});
-                    const ln_2 = try w.toOwnedSlice();
-                    errdefer allocator.free(ln_2);
-
-                    try tooltip_bytes.appendSlice(allocator, ln_2);
-                    try need_freed.append(allocator, ln_2);
-                }
-
-                // Line 3 - Used amount
-                switch (options.*.tooltip_fmt) {
-                    .compact => try w.writer.print("\tUsed: {d:.2} GiB of {d:.2} GiB ({d:.1}%)\r", .{ @as(f32, @floatFromInt(used)) / gibi, @as(f32, @floatFromInt(total)) / gibi, used_pcent }),
-                    .normal => try w.writer.print("\tUsed: {d:.2} GiB ({d:.1}%)\r\r", .{ @as(f32, @floatFromInt(used)) / gibi, used_pcent }),
-                }
-                const ln_3 = try w.toOwnedSlice();
-                errdefer allocator.free(ln_3);
-
-                try tooltip_bytes.appendSlice(allocator, ln_3);
-                try need_freed.append(allocator, ln_3);
-
-                // Line 4 - Flags
-                // TODO: For future usage
-                // if (options.*.tooltip_fmt == .normal) {
-                //     try w.writer.print("\tFlags: {s}\r\r", .{flags});
-                //     const ln_4 = try w.toOwnedSlice();
-                //     errdefer allocator.free(ln_4);
-
-                //     try tooltip_bytes.appendSlice(allocator, ln_4);
-                //     try need_freed.append(allocator, ln_4);
-                // }
-
-                break :append_tooltip;
-            }
-        }
-
-        assert(tooltip_bytes.items.len > 0); // Failed reading or parsing mounts
-
-        break :parse_entries;
-    }
-
-    const css_class: CssClass = switch (root_used_pcent) {
-        0...49 => .low,
-        50...74 => .medium,
-        75...89 => .high,
-        90...100 => .critical,
-        else => unreachable,
-    };
-
-    const css_class_str: []const u8 = css_class.asSlice();
-
-    // Trim trailing whitespace
-    // Number of bytes depends on value of `line_3` in `parse_entries` block of `parseMnts()`, which ends with 1 or 2 newlines depending on chosen tooltip format.
-    const n_whitespace_bytes: usize = switch (options.*.tooltip_fmt) {
-        .normal => 2,
-        .compact => 1,
-    };
-    tooltip_bytes.shrinkAndFree(allocator, tooltip_bytes.items.len - n_whitespace_bytes);
-
-    const tooltip: []const u8 = try tooltip_bytes.toOwnedSlice(allocator);
-
-    return OutputWaybar{
-        .tooltip = tooltip,
-        .class = css_class_str,
-        .percentage = root_used_pcent,
-    };
-}
-
 /// Contains data that will become parts of final output.
 pub const OutputWaybar = struct {
     text: []const u8 = "Storage",
@@ -383,14 +205,14 @@ test "OutputWaybar" {
 }
 
 /// CSS class to pass to Waybar, for dynamic styling.
-const CssClass = enum {
+pub const CssClass = enum {
     low,
     medium,
     high,
     critical,
     err,
 
-    fn asSlice(self: CssClass) []const u8 {
+    pub fn asSlice(self: CssClass) []const u8 {
         return @as([]const u8, @tagName(self));
     }
 };
@@ -402,127 +224,3 @@ test "CssClass" {
     try std.testing.expectEqualSlices(u8, "critical", CssClass.critical.asSlice());
     try std.testing.expectEqualSlices(u8, "err", CssClass.err.asSlice());
 }
-
-/// Command line options
-pub const Options = struct {
-    tooltip_fmt: TooltipFmt = .normal,
-    lang: Lang = .en,
-
-    const Self = @This();
-
-    /// Read command line options and adjust values accordingly
-    pub fn read(self: *Self) error{InvalidOption}!void {
-        var args = process.args();
-        _ = args.next() orelse return; // Discard program name
-
-        // Parse tooltip format
-        const arg_1: [:0]const u8 = args.next() orelse return; // Abort if not given
-        const tooltip_fmt_str: []const u8 = mem.span(arg_1.ptr);
-        self.*.tooltip_fmt = meta.stringToEnum(TooltipFmt, tooltip_fmt_str) orelse return error.InvalidOption;
-
-        // Parse language
-        // TODO: Implement translation(s)
-        const arg_2: [:0]const u8 = args.next() orelse return; // Abort if not given
-        const lang_str: []const u8 = mem.span(arg_2.ptr);
-        self.*.lang = meta.stringToEnum(Lang, lang_str) orelse return error.InvalidOption;
-
-        return;
-    }
-
-    const TooltipFmt = enum(u8) {
-        normal = 0,
-        compact = 1,
-    };
-
-    const Lang = enum(u8) {
-        en = 0,
-        de = 1,
-    };
-};
-
-/// Magic numbers for filesystem types we don't care about, i.e. vfs etc
-///
-/// TODO: It might be easier to instead keep a list of types we DO want.
-///
-/// For a list of magic numbers, see: https://man7.org/linux/man-pages/man2/statfs.2.html
-const ignored_ftypes = enum(c_uint) {
-    autofs = 0x0187,
-    binfmtfs = 0x42494e4d,
-    binfmt_misc, // Dupe of binfmtfs - for compatibility with `.hasField()` fallback method
-    bpf = 0xcafe4a11,
-    cgroup = 0x27e0eb,
-    cgroup2 = 0x63677270,
-    configfs = 0x62656570,
-    debugfs = 0x64626720,
-    devfs = 0x1373,
-    devpts = 0x1cd1,
-    devtmpfs, // Dupe of tmpfs - for compatibility with `.hasField()` fallback
-    efivarfs = 0xde5e81e4,
-    fusectl = 0x65735543,
-    hugetlbfs = 0x958458f6,
-    mqueue = 0x19800202,
-    nsfs = 0x6e736673,
-    proc = 0x9fa0,
-    pstore = 0x6165676c,
-    ramfs = 0x858458f6,
-    securityfs = 0x73636673,
-    squashfs = 0x73717368,
-    sysfs = 0x62656572,
-    tmpfs = 0x01021994,
-    tracefs = 0x74726163,
-
-    /// If given `f_type` magic number is a member of this enum, return its enum value; else, return null.
-    /// `f_type` is the value of field `.f_type` in the result of `statvfs()` call.
-    fn fromCInt(f_type: c_uint) ?ignored_ftypes {
-        return enums.fromInt(ignored_ftypes, f_type) orelse null;
-    }
-
-    /// Check if field `name` is a member of this enum.
-    /// Fallback for systems where `struct_statvfs` does not include `.f_type` field and thus can't use `.fromCInt()`.
-    ///
-    /// This is inefficient; prefer to use `.fromCInt()` when possible.
-    fn hasField(name: []const u8) bool {
-        inline for (meta.fields(ignored_ftypes)) |field| {
-            if (mem.eql(u8, field.name, name))
-                return true;
-        }
-        return false;
-    }
-};
-
-test "ignored_ftypes" {
-    try std.testing.expect(ignored_ftypes.fromCInt(@as(c_uint, 1)) == null);
-    try std.testing.expect(ignored_ftypes.fromCInt(@as(c_uint, 16914836)) == .tmpfs);
-    try std.testing.expect(ignored_ftypes.fromCInt(@as(c_uint, 3730735588)) == .efivarfs);
-
-    try std.testing.expect(ignored_ftypes.hasField("tmpfs"));
-    try std.testing.expect(ignored_ftypes.hasField("nonexistent") == false);
-}
-
-// /// Deprecated
-// const ignored_types = &[_][]const u8{
-//     "-",
-//     "autofs",
-//     "binfmtfs",
-//     "binfmt_misc",
-//     "bpf",
-//     "cgroup",
-//     "cgroup2",
-//     "configfs",
-//     "debugfs",
-//     "devfs",
-//     "devpts",
-//     "devtmpfs",
-//     "efivarfs",
-//     "fuse.portal",
-//     "fusectl",
-//     "hugetlbfs",
-//     "mqueue",
-//     "proc",
-//     "pstore",
-//     "securityfs",
-//     "sys",
-//     "sysfs",
-//     "tmpfs",
-//     "tracefs",
-// };


### PR DESCRIPTION
Moving some functions from `root.zig` to `main.zig`, that are exclusive to this disk usage module, so `root.zig` can be shared between this and any future modules.

Also including a couple small doc edits I had pending (`TODO.md`/`CONTRIBUTING.md`).